### PR TITLE
Added waitFor chmod operation on Bash task

### DIFF
--- a/piper-core/src/main/java/com/creactiviti/piper/core/taskhandler/script/Bash.java
+++ b/piper-core/src/main/java/com/creactiviti/piper/core/taskhandler/script/Bash.java
@@ -34,7 +34,10 @@ public class Bash implements TaskHandler<String> {
     File logFile = File.createTempFile("log", null);
     FileUtils.writeStringToFile(scriptFile, aTask.getRequiredString("script"));
     try (PrintStream stream = new PrintStream(logFile);) {
-      Runtime.getRuntime().exec(String.format("chmod u+x %s",scriptFile.getAbsolutePath()));
+      Process chmod = Runtime.getRuntime().exec(String.format("chmod u+x %s",scriptFile.getAbsolutePath()));
+      int chmodRetCode = chmod.waitFor();
+      if(chmodRetCode != 0)
+        throw new ExecuteException("Failed to chmod", chmodRetCode);
       CommandLine cmd = new CommandLine (scriptFile.getAbsolutePath());
       logger.debug("{}",cmd);
       DefaultExecutor exec = new DefaultExecutor();


### PR DESCRIPTION
Fix Issue #5.
The problem was that the chmod operation ran asynchronously and you weren't waiting for the end of this execution. This caused the intermittent fault where sometimes we had permission to execute it and sometimes we didn't.
I've included a check for 0 return code for good measure.