### PR TITLE
Added cast methods for all primitive types

### DIFF
--- a/piper-core/src/main/java/com/creactiviti/piper/core/task/SpelTaskEvaluator.java
+++ b/piper-core/src/main/java/com/creactiviti/piper/core/task/SpelTaskEvaluator.java
@@ -90,13 +90,28 @@ public class SpelTaskEvaluator implements TaskEvaluator {
   
   private MethodResolver methodResolver () {
     return (ctx,target,name,args) -> {
-      if("range".equals(name)) {
-        return range();
+      switch(name) {
+        case "range":
+          return range();
+        case "boolean":
+          return cast(Boolean.class);
+        case "byte":
+          return cast(Byte.class);
+        case "char":
+          return cast(Character.class);
+        case "short":
+          return cast(Short.class);
+        case "int":
+          return cast(Integer.class);
+        case "long":
+          return cast(Long.class);
+        case "float":
+          return cast(Float.class);
+        case "double":
+          return cast(Double.class);
+        default:
+          return null;
       }
-      else if("int".equals(name)) {
-        return toInt();
-      }
-      return null;
     };
   }
   
@@ -109,9 +124,9 @@ public class SpelTaskEvaluator implements TaskEvaluator {
     };
   }
   
-  private MethodExecutor toInt () {
+  private <T> MethodExecutor cast(Class<T> type) {
     return (ctx,target,args) -> {
-      Integer value = (Integer) ConvertUtils.convert(args[0], Integer.class);
+      T value = type.cast(ConvertUtils.convert(args[0], type));
       return new TypedValue(value);
     };
   }

--- a/piper-core/src/test/java/com/creactiviti/piper/core/task/SpelTaskEvaluatorTests.java
+++ b/piper-core/src/test/java/com/creactiviti/piper/core/task/SpelTaskEvaluatorTests.java
@@ -20,7 +20,7 @@ public class SpelTaskEvaluatorTests {
     TaskExecution evaluated = evaluator.evaluate(jt, new MapContext(Collections.EMPTY_MAP));
     Assert.assertEquals(evaluated.asMap(),jt.asMap());
   }
-  
+
   @Test
   public void test2 () {
     SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
@@ -28,7 +28,7 @@ public class SpelTaskEvaluatorTests {
     TaskExecution evaluated = evaluator.evaluate(jt, new MapContext(Collections.EMPTY_MAP));
     Assert.assertEquals(evaluated.asMap(),jt.asMap());
   }
-  
+
   @Test
   public void test3 () {
     SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
@@ -36,7 +36,7 @@ public class SpelTaskEvaluatorTests {
     TaskExecution evaluated = evaluator.evaluate(jt, new MapContext(Collections.singletonMap("name", "arik")));
     Assert.assertEquals("arik",evaluated.getString("hello"));
   }
-  
+
   @Test
   public void test4 () {
     SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
@@ -47,7 +47,7 @@ public class SpelTaskEvaluatorTests {
     TaskExecution evaluated = evaluator.evaluate(jt, ctx);
     Assert.assertEquals("Arik Cohen",evaluated.getString("hello"));
   }
-  
+
   @Test
   public void test5 () {
     SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
@@ -57,7 +57,7 @@ public class SpelTaskEvaluatorTests {
     TaskExecution evaluated = evaluator.evaluate(jt, ctx);
     Assert.assertEquals(Integer.valueOf(5),((Integer)evaluated.get("hello")));
   }
-  
+
   @Test
   public void test6 () {
     SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
@@ -68,7 +68,7 @@ public class SpelTaskEvaluatorTests {
     TaskExecution evaluated = evaluator.evaluate(jt, ctx);
     Assert.assertEquals(Arrays.asList("Arik","Cohen"),evaluated.getList("list", String.class));
   }
-  
+
   @Test
   public void test7 () {
     SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
@@ -78,7 +78,7 @@ public class SpelTaskEvaluatorTests {
     TaskExecution evaluated = evaluator.evaluate(jt, ctx);
     Assert.assertEquals(MapObject.of(Collections.singletonMap("hello", "Arik")),evaluated.getMap("map"));
   }
-  
+
   @Test
   public void test8 () {
     SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
@@ -89,7 +89,7 @@ public class SpelTaskEvaluatorTests {
     TaskExecution evaluated = evaluator.evaluate(jt, ctx);
     Assert.assertEquals(Integer.valueOf(15),evaluated.getInteger("mult"));
   }
-  
+
   @Test
   public void test9 () {
     SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
@@ -121,7 +121,7 @@ public class SpelTaskEvaluatorTests {
     TaskExecution evaluated = evaluator.evaluate(jt, new MapContext(Collections.singletonMap("number", 1)));
     Assert.assertEquals(Integer.valueOf(3),evaluated.get("thing"));
   }
-  
+
   @Test
   public void test13 () {
     SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
@@ -129,7 +129,7 @@ public class SpelTaskEvaluatorTests {
     TaskExecution evaluated = evaluator.evaluate(jt, new MapContext(Collections.EMPTY_MAP));
     Assert.assertEquals("${number*3}",evaluated.get("thing"));
   }
-  
+
   @Test
   public void test14 () {
     SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
@@ -137,7 +137,7 @@ public class SpelTaskEvaluatorTests {
     TaskExecution evaluated = evaluator.evaluate(jt, new MapContext(Collections.EMPTY_MAP));
     Assert.assertEquals(Arrays.asList(1,2,3),evaluated.get("list"));
   }
-  
+
   @Test
   public void test15 () {
     SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
@@ -145,7 +145,7 @@ public class SpelTaskEvaluatorTests {
     TaskExecution evaluated = evaluator.evaluate(jt, new MapContext(Collections.EMPTY_MAP));
     Assert.assertEquals(Arrays.asList(1,2,3),evaluated.getMap("sub").get("list"));
   }
-  
+
   @Test
   public void test16 () {
     SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
@@ -153,13 +153,68 @@ public class SpelTaskEvaluatorTests {
     TaskExecution evaluated = evaluator.evaluate(jt, new MapContext(ImmutableMap.of("item1", "hello","item2","world")));
     Assert.assertEquals("hello-world",evaluated.get("message"));
   }
-  
+
   @Test
   public void test17 () {
+    SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
+    TaskExecution jt = SimpleTaskExecution.createFrom("someBoolean", "${boolean('1')}");
+    TaskExecution evaluated = evaluator.evaluate(jt, new MapContext(Collections.EMPTY_MAP));
+    Assert.assertEquals(Boolean.valueOf(true),evaluated.get("someBoolean"));
+  }
+
+  @Test
+  public void test18 () {
+    SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
+    TaskExecution jt = SimpleTaskExecution.createFrom("someByte", "${byte('127')}");
+    TaskExecution evaluated = evaluator.evaluate(jt, new MapContext(Collections.EMPTY_MAP));
+    Assert.assertEquals(Byte.valueOf(Byte.MAX_VALUE),evaluated.get("someByte"));
+  }
+
+  @Test
+  public void test19 () {
+    SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
+    TaskExecution jt = SimpleTaskExecution.createFrom("someChar", "${char('c')}");
+    TaskExecution evaluated = evaluator.evaluate(jt, new MapContext(Collections.EMPTY_MAP));
+    Assert.assertEquals(Character.valueOf('c'),evaluated.get("someChar"));
+  }
+
+  @Test
+  public void test20 () {
+    SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
+    TaskExecution jt = SimpleTaskExecution.createFrom("someShort", "${short('32767')}");
+    TaskExecution evaluated = evaluator.evaluate(jt, new MapContext(Collections.EMPTY_MAP));
+    Assert.assertEquals(Short.valueOf(Short.MAX_VALUE),evaluated.get("someShort"));
+  }
+
+  @Test
+  public void test21 () {
     SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
     TaskExecution jt = SimpleTaskExecution.createFrom("someInt", "${int('1')}");
     TaskExecution evaluated = evaluator.evaluate(jt, new MapContext(Collections.EMPTY_MAP));
     Assert.assertEquals(Integer.valueOf(1),evaluated.get("someInt"));
   }
-  
+
+  @Test
+  public void test22 () {
+    SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
+    TaskExecution jt = SimpleTaskExecution.createFrom("someLong", "${long('1')}");
+    TaskExecution evaluated = evaluator.evaluate(jt, new MapContext(Collections.EMPTY_MAP));
+    Assert.assertEquals(Long.valueOf(1L),evaluated.get("someLong"));
+  }
+
+  @Test
+  public void test23 () {
+    SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
+    TaskExecution jt = SimpleTaskExecution.createFrom("someFloat", "${float('1.337')}");
+    TaskExecution evaluated = evaluator.evaluate(jt, new MapContext(Collections.EMPTY_MAP));
+    Assert.assertEquals(Float.valueOf(1.337f),evaluated.get("someFloat"));
+  }
+
+  @Test
+  public void test24 () {
+    SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
+    TaskExecution jt = SimpleTaskExecution.createFrom("someDouble", "${double('1.337')}");
+    TaskExecution evaluated = evaluator.evaluate(jt, new MapContext(Collections.EMPTY_MAP));
+    Assert.assertEquals(Double.valueOf(1.337d),evaluated.get("someDouble"));
+  }
 }


### PR DESCRIPTION
While using piper I came across the need to cast a float number.
Meanwhile I've added cast methods for all the primitive types and tests to verify them.