### PR TITLE
fix typo

### DIFF
--- a/piper-core/src/main/java/com/creactiviti/piper/core/Coordinator.java
+++ b/piper-core/src/main/java/com/creactiviti/piper/core/Coordinator.java
@@ -88,7 +88,7 @@ public class Coordinator {
     SimpleJob job = new SimpleJob();
     job.setId(UUIDGenerator.generate());
     job.setLabel(jobParams.getString(DSL.LABEL,pipeline.getLabel()));
-    job.setPriority(jobParams.getInteger(DSL.PRIORTIY, Prioritizable.DEFAULT_PRIORITY));
+    job.setPriority(jobParams.getInteger(DSL.PRIORITY, Prioritizable.DEFAULT_PRIORITY));
     job.setPipelineId(pipeline.getId());
     job.setStatus(JobStatus.CREATED);
     job.setCreateTime(new Date());

--- a/piper-core/src/main/java/com/creactiviti/piper/core/DSL.java
+++ b/piper-core/src/main/java/com/creactiviti/piper/core/DSL.java
@@ -59,7 +59,7 @@ public class DSL {
   
   public static final String TAGS = "tags";
   
-  public static final String PRIORTIY = "priority";
+  public static final String PRIORITY = "priority";
   
   public static final String SWITCH = "switch";
   
@@ -98,7 +98,7 @@ public class DSL {
                                                               STATUS,
                                                               ERROR,
                                                               EXECUTION,
-                                                              PRIORTIY,
+                                                              PRIORITY,
                                                               CURRENT_TASK
                                                             }; 
   

--- a/piper-core/src/main/java/com/creactiviti/piper/core/job/SimpleJob.java
+++ b/piper-core/src/main/java/com/creactiviti/piper/core/job/SimpleJob.java
@@ -144,11 +144,11 @@ public class SimpleJob extends MapObject implements Job {
   
   @Override
   public int getPriority() {
-    return getInteger(DSL.PRIORTIY, Prioritizable.DEFAULT_PRIORITY);
+    return getInteger(DSL.PRIORITY, Prioritizable.DEFAULT_PRIORITY);
   }
   
   public void setPriority (int aPriority) {
-    set(DSL.PRIORTIY, aPriority);
+    set(DSL.PRIORITY, aPriority);
   }
   
   @Override

--- a/piper-core/src/main/java/com/creactiviti/piper/core/task/SimpleTaskExecution.java
+++ b/piper-core/src/main/java/com/creactiviti/piper/core/task/SimpleTaskExecution.java
@@ -163,11 +163,11 @@ public class SimpleTaskExecution extends SimplePipelineTask implements TaskExecu
   
   @Override
   public int getPriority() {
-    return getInteger(DSL.PRIORTIY, Prioritizable.DEFAULT_PRIORITY);
+    return getInteger(DSL.PRIORITY, Prioritizable.DEFAULT_PRIORITY);
   }
   
   public void setPriority (int aPriority) {
-    set(DSL.PRIORTIY, aPriority);
+    set(DSL.PRIORITY, aPriority);
   }
     
   /**


### PR DESCRIPTION
Wrong spell `PRIORTIY`, I fixed it to `PRIORITY`.