### PR TITLE
added string join and list concatenation SpEL methods

### DIFF
--- a/src/main/java/com/creactiviti/piper/core/task/SpelTaskEvaluator.java
+++ b/src/main/java/com/creactiviti/piper/core/task/SpelTaskEvaluator.java
@@ -131,6 +131,8 @@ public class SpelTaskEvaluator implements TaskEvaluator {
           return join();
         case "concat":
           return concat();
+        case "flatten":
+          return flatten();
         default:
           return null;
       }
@@ -176,6 +178,16 @@ public class SpelTaskEvaluator implements TaskEvaluator {
       joined.addAll(l1);
       joined.addAll(l2);
       return new TypedValue(joined);
+    };
+  }
+
+  private <T> MethodExecutor flatten () {
+    return (ctx,target,args) -> {
+      List<List<T>> list = (List<List<T>>) args[0];
+      List<T> flat = list.stream()
+                         .flatMap(List::stream)
+                         .collect(Collectors.toList());
+      return new TypedValue(flat);
     };
   }
 }

--- a/src/main/java/com/creactiviti/piper/core/task/SpelTaskEvaluator.java
+++ b/src/main/java/com/creactiviti/piper/core/task/SpelTaskEvaluator.java
@@ -127,6 +127,10 @@ public class SpelTaskEvaluator implements TaskEvaluator {
           return cast(Float.class);
         case "double":
           return cast(Double.class);
+        case "join":
+          return join();
+        case "concat":
+          return concat();
         default:
           return null;
       }
@@ -152,5 +156,28 @@ public class SpelTaskEvaluator implements TaskEvaluator {
       return new TypedValue(value);
     };
   }
-  
+
+  private <T> MethodExecutor join () {
+    return (ctx,target,args) -> {
+      String separator = (String) args[0];
+      List<T> values = (List<T>) args[1];
+      List<String> strings = new ArrayList<>(values.size());
+      for (T obj : values) {
+        strings.add(String.valueOf(obj));
+      }
+      String str = String.join(separator, strings);
+      return new TypedValue(str);
+    };
+  }
+
+  private <T> MethodExecutor concat () {
+    return (ctx,target,args) -> {
+      List<T> l1 = (List<T>) args[0];
+      List<T> l2 = (List<T>) args[1];
+      List<T> joined = new ArrayList<T>(l1.size()+l2.size());
+      joined.addAll(l1);
+      joined.addAll(l2);
+      return new TypedValue(joined);
+    };
+  }
 }

--- a/src/main/java/com/creactiviti/piper/core/task/SpelTaskEvaluator.java
+++ b/src/main/java/com/creactiviti/piper/core/task/SpelTaskEvaluator.java
@@ -161,11 +161,9 @@ public class SpelTaskEvaluator implements TaskEvaluator {
     return (ctx,target,args) -> {
       String separator = (String) args[0];
       List<T> values = (List<T>) args[1];
-      List<String> strings = new ArrayList<>(values.size());
-      for (T obj : values) {
-        strings.add(String.valueOf(obj));
-      }
-      String str = String.join(separator, strings);
+      String str = values.stream()
+                         .map(String::valueOf)
+                         .collect(Collectors.joining(separator));
       return new TypedValue(str);
     };
   }

--- a/src/test/java/com/creactiviti/piper/core/task/SpelTaskEvaluatorTests.java
+++ b/src/test/java/com/creactiviti/piper/core/task/SpelTaskEvaluatorTests.java
@@ -202,8 +202,6 @@ public class SpelTaskEvaluatorTests {
     Assert.assertEquals(Long.valueOf(1L),evaluated.get("someLong"));
   }
 
-
-  
   @Test
   public void test23 () {
     SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
@@ -218,6 +216,45 @@ public class SpelTaskEvaluatorTests {
     TaskExecution jt = SimpleTaskExecution.createFrom("someDouble", "${double('1.337')}");
     TaskExecution evaluated = evaluator.evaluate(jt, new MapContext(Collections.EMPTY_MAP));
     Assert.assertEquals(Double.valueOf(1.337d),evaluated.get("someDouble"));
-  }  
-  
+  }
+
+  @Test
+  public void test25 () {
+    SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
+    TaskExecution jt = SimpleTaskExecution.createFrom("joined", "${join(',',range(1,3))}");
+    TaskExecution evaluated = evaluator.evaluate(jt, new MapContext(Collections.EMPTY_MAP));
+    Assert.assertEquals("1,2,3",evaluated.get("joined"));
+  }
+
+  @Test
+  public void test26 () {
+    SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
+    TaskExecution jt = SimpleTaskExecution.createFrom("joined", "${join(',',range(1,1))}");
+    TaskExecution evaluated = evaluator.evaluate(jt, new MapContext(Collections.EMPTY_MAP));
+    Assert.assertEquals("1",evaluated.get("joined"));
+  }
+
+  @Test
+  public void test27 () {
+    SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
+    TaskExecution jt = SimpleTaskExecution.createFrom("joined", "${join(' and ',{'a','b','c'})}");
+    TaskExecution evaluated = evaluator.evaluate(jt, new MapContext(Collections.EMPTY_MAP));
+    Assert.assertEquals("a and b and c",evaluated.get("joined"));
+  }
+
+  @Test
+  public void test28 () {
+    SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
+    TaskExecution jt = SimpleTaskExecution.createFrom("concatenated", "${concat({'a','b','c'}, {'d','e','f'})}");
+    TaskExecution evaluated = evaluator.evaluate(jt, new MapContext(Collections.EMPTY_MAP));
+    Assert.assertEquals(Arrays.asList("a","b","c","d","e","f"),evaluated.get("concatenated"));
+  }
+
+  @Test
+  public void test29 () {
+    SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
+    TaskExecution jt = SimpleTaskExecution.createFrom("concatenated", "${concat({'a','b','c'}, range(1,3))}");
+    TaskExecution evaluated = evaluator.evaluate(jt, new MapContext(Collections.EMPTY_MAP));
+    Assert.assertEquals(Arrays.asList("a","b","c",1,2,3),evaluated.get("concatenated"));
+  }
 }

--- a/src/test/java/com/creactiviti/piper/core/task/SpelTaskEvaluatorTests.java
+++ b/src/test/java/com/creactiviti/piper/core/task/SpelTaskEvaluatorTests.java
@@ -257,4 +257,20 @@ public class SpelTaskEvaluatorTests {
     TaskExecution evaluated = evaluator.evaluate(jt, new MapContext(Collections.EMPTY_MAP));
     Assert.assertEquals(Arrays.asList("a","b","c",1,2,3),evaluated.get("concatenated"));
   }
+
+  @Test
+  public void test30 () {
+    SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
+    TaskExecution jt = SimpleTaskExecution.createFrom("flattened", "${flatten({{'a','b','c'},{'d','e','f'}})}");
+    TaskExecution evaluated = evaluator.evaluate(jt, new MapContext(Collections.EMPTY_MAP));
+    Assert.assertEquals(Arrays.asList("a","b","c","d","e","f"),evaluated.get("flattened"));
+  }
+
+  @Test
+  public void test31 () {
+    SpelTaskEvaluator evaluator = new SpelTaskEvaluator();
+    TaskExecution jt = SimpleTaskExecution.createFrom("flattened", "${flatten({{'a','b','c'},range(1,3)})}");
+    TaskExecution evaluated = evaluator.evaluate(jt, new MapContext(Collections.EMPTY_MAP));
+    Assert.assertEquals(Arrays.asList("a","b","c",1,2,3),evaluated.get("flattened"));
+  }
 }


### PR DESCRIPTION
This adds some methods I found necessary to avoid some crappy hacks on the pipelines:

- `join('separator', list)` takes a list, converts all items to strings and joins them by the provided separator
- `concat(list1, list2)` takes two lists and concatenates them together
- `flatten(list)` takes a list of lists and flattens it