### PR TITLE
add application.pid to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target
 /.apt_generated/
 *.iml
 .sts4-cache/
+application.pid


### PR DESCRIPTION
As a consequence of #10, when launching `piper` with scripts, for instance `./scripts/development.sh` at the root of the project, the file `application.pid` is created. That file should be ignored in Git (that would leave the working tree clean).