### PR TITLE
Add task progress capability

### DIFF
--- a/scripts/trigger-pipeline-download.sh
+++ b/scripts/trigger-pipeline-download.sh
@@ -1,0 +1,1 @@
+ curl -s -X POST -H Content-Type:application/json -d '{"pipelineId":"demo/download"}' http://localhost:8080/jobs

--- a/src/main/java/com/creactiviti/piper/config/CoordinatorConfiguration.java
+++ b/src/main/java/com/creactiviti/piper/config/CoordinatorConfiguration.java
@@ -15,49 +15,25 @@
  */
 package com.creactiviti.piper.config;
 
-import java.util.Arrays;
-import java.util.List;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Lazy;
-
-import com.creactiviti.piper.core.Coordinator;
-import com.creactiviti.piper.core.DefaultJobExecutor;
-import com.creactiviti.piper.core.DefaultTaskCompletionHandler;
-import com.creactiviti.piper.core.EachTaskCompletionHandler;
-import com.creactiviti.piper.core.ForkTaskCompletionHandler;
-import com.creactiviti.piper.core.MapTaskCompletionHandler;
-import com.creactiviti.piper.core.SwitchTaskCompletionHandler;
-import com.creactiviti.piper.core.TaskCompletionHandler;
-import com.creactiviti.piper.core.TaskCompletionHandlerChain;
+import com.creactiviti.piper.core.*;
 import com.creactiviti.piper.core.annotations.ConditionalOnCoordinator;
 import com.creactiviti.piper.core.context.Context;
 import com.creactiviti.piper.core.context.ContextRepository;
 import com.creactiviti.piper.core.error.ErrorHandler;
 import com.creactiviti.piper.core.error.ErrorHandlerChain;
 import com.creactiviti.piper.core.error.TaskExecutionErrorHandler;
-import com.creactiviti.piper.core.event.DistributedEventPublisher;
-import com.creactiviti.piper.core.event.JobStatusWebhookEventListener;
-import com.creactiviti.piper.core.event.TaskStartedEventListener;
-import com.creactiviti.piper.core.event.TaskStartedWebhookEventListener;
+import com.creactiviti.piper.core.event.*;
 import com.creactiviti.piper.core.job.JobRepository;
 import com.creactiviti.piper.core.messenger.Messenger;
 import com.creactiviti.piper.core.pipeline.PipelineRepository;
-import com.creactiviti.piper.core.task.ControlTaskDispatcher;
-import com.creactiviti.piper.core.task.CounterRepository;
-import com.creactiviti.piper.core.task.EachTaskDispatcher;
-import com.creactiviti.piper.core.task.ForkTaskDispatcher;
-import com.creactiviti.piper.core.task.MapTaskDispatcher;
-import com.creactiviti.piper.core.task.ParallelTaskCompletionHandler;
-import com.creactiviti.piper.core.task.ParallelTaskDispatcher;
-import com.creactiviti.piper.core.task.SwitchTaskDispatcher;
-import com.creactiviti.piper.core.task.TaskDispatcher;
-import com.creactiviti.piper.core.task.TaskDispatcherChain;
-import com.creactiviti.piper.core.task.TaskDispatcherResolver;
-import com.creactiviti.piper.core.task.TaskExecutionRepository;
-import com.creactiviti.piper.core.task.WorkTaskDispatcher;
+import com.creactiviti.piper.core.task.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @ConditionalOnCoordinator
@@ -239,7 +215,12 @@ public class CoordinatorConfiguration {
   TaskStartedEventListener taskStartedEventListener () {
     return new TaskStartedEventListener(taskExecutionRepo, taskDispatcher());
   }
-  
+
+  @Bean
+  TaskProgressedEventListener taskProgressedEventListener () {
+    return new TaskProgressedEventListener(taskExecutionRepo);
+  }
+
   @Bean
   JobStatusWebhookEventListener webhookEventHandler () {
     return new JobStatusWebhookEventListener(jobRepository);

--- a/src/main/java/com/creactiviti/piper/config/WorkerConfiguration.java
+++ b/src/main/java/com/creactiviti/piper/config/WorkerConfiguration.java
@@ -16,6 +16,7 @@
 package com.creactiviti.piper.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
@@ -42,6 +43,7 @@ public class WorkerConfiguration {
   }
 
   @Bean
+  @Qualifier("Worker")
   DistributedEventPublisher workerEventPublisher () {
     return new DistributedEventPublisher (messenger);
   }

--- a/src/main/java/com/creactiviti/piper/core/DSL.java
+++ b/src/main/java/com/creactiviti/piper/core/DSL.java
@@ -59,11 +59,13 @@ public class DSL {
   public static final String END_TIME = "endTime";
   
   public static final String STATUS = "status";
-  
+
+  public static final String PROGRESS = "progress";
+
   public static final String OUTPUT = "output";
   
   public static final String ERROR = "error";
-  
+
   public static final String TASKS = "tasks";
   
   public static final String INPUTS = "inputs";

--- a/src/main/java/com/creactiviti/piper/core/MapObject.java
+++ b/src/main/java/com/creactiviti/piper/core/MapObject.java
@@ -15,22 +15,14 @@
  */
 package com.creactiviti.piper.core;
 
-import java.lang.reflect.Array;
-import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
+import com.google.common.base.Throwables;
 import org.apache.commons.beanutils.ConvertUtils;
 import org.apache.commons.lang3.time.DateUtils;
 import org.springframework.util.Assert;
 
-import com.google.common.base.Throwables;
+import java.lang.reflect.Array;
+import java.text.ParseException;
+import java.util.*;
 
 /**
  * @author Arik Cohen
@@ -217,7 +209,7 @@ public class MapObject implements Map<String, Object>, Accessor, Mutator {
   public int getInteger(Object aKey, int aDefaultValue) {
     return get(aKey, Integer.class, aDefaultValue);
   }
-  
+
   @Override
   public Date getDate(Object aKey) {
     Object value = get(aKey);

--- a/src/main/java/com/creactiviti/piper/core/Worker.java
+++ b/src/main/java/com/creactiviti/piper/core/Worker.java
@@ -86,7 +86,7 @@ public class Worker {
           }
         }
         completion.setStatus(TaskStatus.COMPLETED);
-        completion.setProgess(100.f);
+        completion.setProgress(100);
         completion.setEndTime(new Date());
         completion.setExecutionTime(System.currentTimeMillis()-startTime);
         messenger.send(Queues.COMPLETIONS, completion);

--- a/src/main/java/com/creactiviti/piper/core/Worker.java
+++ b/src/main/java/com/creactiviti/piper/core/Worker.java
@@ -15,23 +15,6 @@
  */
 package com.creactiviti.piper.core;
 
-import java.time.Duration;
-import java.util.Date;
-import java.util.Map;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
-import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.Assert;
-
 import com.creactiviti.piper.core.context.MapContext;
 import com.creactiviti.piper.core.error.ErrorObject;
 import com.creactiviti.piper.core.event.EventPublisher;
@@ -39,14 +22,16 @@ import com.creactiviti.piper.core.event.Events;
 import com.creactiviti.piper.core.event.PiperEvent;
 import com.creactiviti.piper.core.messenger.Messenger;
 import com.creactiviti.piper.core.messenger.Queues;
-import com.creactiviti.piper.core.task.ControlTask;
-import com.creactiviti.piper.core.task.SimpleTaskExecution;
-import com.creactiviti.piper.core.task.SpelTaskEvaluator;
-import com.creactiviti.piper.core.task.TaskEvaluator;
-import com.creactiviti.piper.core.task.TaskExecution;
-import com.creactiviti.piper.core.task.TaskHandler;
-import com.creactiviti.piper.core.task.TaskHandlerResolver;
-import com.creactiviti.piper.core.task.TaskStatus;
+import com.creactiviti.piper.core.task.*;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.Assert;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.*;
 
 /**
  * <p>The class responsible for executing tasks spawned by the {@link Coordinator}.</p>
@@ -101,6 +86,7 @@ public class Worker {
           }
         }
         completion.setStatus(TaskStatus.COMPLETED);
+        completion.setProgess(100.f);
         completion.setEndTime(new Date());
         completion.setExecutionTime(System.currentTimeMillis()-startTime);
         messenger.send(Queues.COMPLETIONS, completion);

--- a/src/main/java/com/creactiviti/piper/core/error/Progressable.java
+++ b/src/main/java/com/creactiviti/piper/core/error/Progressable.java
@@ -8,7 +8,7 @@ package com.creactiviti.piper.core.error;
  */
 public interface Progressable {
     /**
-     *  @return the current progress value, a number between 0. and 1., or <code>null</code> otherwise.
+     *  @return the current progress value, a number between 0 and 100.
      */
-    Float getProgress ();
+    int getProgress ();
 }

--- a/src/main/java/com/creactiviti/piper/core/error/Progressable.java
+++ b/src/main/java/com/creactiviti/piper/core/error/Progressable.java
@@ -1,0 +1,14 @@
+package com.creactiviti.piper.core.error;
+
+/**
+ * An interface which denotes an object (typically a {@link com.creactiviti.piper.core.task.Task} able to
+ * report its progress.
+ *
+ * @since Sep 06, 2018
+ */
+public interface Progressable {
+    /**
+     *  @return the current progress value, a number between 0. and 1., or <code>null</code> otherwise.
+     */
+    Float getProgress ();
+}

--- a/src/main/java/com/creactiviti/piper/core/event/Events.java
+++ b/src/main/java/com/creactiviti/piper/core/event/Events.java
@@ -23,8 +23,8 @@ package com.creactiviti.piper.core.event;
 public interface Events {
 
   public static final String TASK_STARTED = "task.started";
-  
+
+  public static final String TASK_PROGRESSED = "task.progressed";
+
   public static final String JOB_STATUS = "job.status";
-  
-  
 }

--- a/src/main/java/com/creactiviti/piper/core/event/TaskProgressedEventListener.java
+++ b/src/main/java/com/creactiviti/piper/core/event/TaskProgressedEventListener.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.creactiviti.piper.core.event;
+
+import com.creactiviti.piper.core.task.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * @since Sep 06, 2018
+ */
+public class TaskProgressedEventListener implements EventListener {
+
+  private final TaskExecutionRepository taskExecutionRepository;
+
+  private final Logger logger = LoggerFactory.getLogger(getClass());
+
+  public TaskProgressedEventListener(TaskExecutionRepository aTaskExecutionRepository) {
+    taskExecutionRepository = aTaskExecutionRepository;
+  }
+
+  @Override
+  public void onApplicationEvent (PiperEvent aEvent) {
+    if(Events.TASK_PROGRESSED.equals(aEvent.getType())) {
+      String taskId = aEvent.getString("taskId");
+      Float progress = aEvent.getFloat("progress");
+
+      TaskExecution task = taskExecutionRepository.findOne(taskId);
+
+      if(task == null) {
+        logger.error("Unknown task: {}",taskId);
+      } else {
+        SimpleTaskExecution mtask = SimpleTaskExecution.createForUpdate(task);
+
+        mtask.setProgess(progress);
+
+        taskExecutionRepository.merge(mtask);
+      }
+    }
+  }
+
+}

--- a/src/main/java/com/creactiviti/piper/core/event/TaskProgressedEventListener.java
+++ b/src/main/java/com/creactiviti/piper/core/event/TaskProgressedEventListener.java
@@ -37,7 +37,7 @@ public class TaskProgressedEventListener implements EventListener {
   public void onApplicationEvent (PiperEvent aEvent) {
     if(Events.TASK_PROGRESSED.equals(aEvent.getType())) {
       String taskId = aEvent.getString("taskId");
-      Float progress = aEvent.getFloat("progress");
+      int progress = aEvent.getInteger("progress", 0);
 
       TaskExecution task = taskExecutionRepository.findOne(taskId);
 
@@ -46,7 +46,7 @@ public class TaskProgressedEventListener implements EventListener {
       } else {
         SimpleTaskExecution mtask = SimpleTaskExecution.createForUpdate(task);
 
-        mtask.setProgess(progress);
+        mtask.setProgress(progress);
 
         taskExecutionRepository.merge(mtask);
       }

--- a/src/main/java/com/creactiviti/piper/core/task/JdbcTaskExecutionRepository.java
+++ b/src/main/java/com/creactiviti/piper/core/task/JdbcTaskExecutionRepository.java
@@ -50,7 +50,7 @@ public class JdbcTaskExecutionRepository implements TaskExecutionRepository {
   @Override
   public void create (TaskExecution aTaskExecution) {
     SqlParameterSource sqlParameterSource = createSqlParameterSource(aTaskExecution);
-    jdbc.update("insert into task_execution (id,parent_id,job_id,serialized_execution,status,create_time,priority,task_number) values (:id,:parentId,:jobId,:serializedExecution,:status,:createTime,:priority,:taskNumber)", sqlParameterSource);
+    jdbc.update("insert into task_execution (id,parent_id,job_id,serialized_execution,status,progress,create_time,priority,task_number) values (:id,:parentId,:jobId,:serializedExecution,:status,:progress,:createTime,:priority,:taskNumber)", sqlParameterSource);
   }
   
   @Override
@@ -66,7 +66,7 @@ public class JdbcTaskExecutionRepository implements TaskExecutionRepository {
       merged.setStartTime(current.getStartTime());      
     }
     SqlParameterSource sqlParameterSource = createSqlParameterSource(merged);
-    jdbc.update("update task_execution set serialized_execution=:serializedExecution,status=:status,start_time=:startTime,end_time=:endTime where id = :id ", sqlParameterSource);
+    jdbc.update("update task_execution set serialized_execution=:serializedExecution,status=:status,progress=:progress,start_time=:startTime,end_time=:endTime where id = :id ", sqlParameterSource);
     return merged;
   }
   
@@ -85,6 +85,7 @@ public class JdbcTaskExecutionRepository implements TaskExecutionRepository {
     sqlParameterSource.addValue("parentId", aTaskExecution.getParentId());
     sqlParameterSource.addValue("jobId", aTaskExecution.getJobId());
     sqlParameterSource.addValue("status", aTaskExecution.getStatus().toString());
+    sqlParameterSource.addValue("progress", aTaskExecution.getProgress());
     sqlParameterSource.addValue("createTime", aTaskExecution.getCreateTime());
     sqlParameterSource.addValue("startTime", aTaskExecution.getStartTime());
     sqlParameterSource.addValue("endTime", aTaskExecution.getEndTime());

--- a/src/main/java/com/creactiviti/piper/core/task/SimpleTaskExecution.java
+++ b/src/main/java/com/creactiviti/piper/core/task/SimpleTaskExecution.java
@@ -80,11 +80,11 @@ public class SimpleTaskExecution extends SimplePipelineTask implements TaskExecu
   }
 
   @Override
-  public Float getProgress() {
-    return get(DSL.PROGRESS, Float.class);
+  public int getProgress() {
+    return get(DSL.PROGRESS, Integer.class, 0);
   }
 
-  public void setProgess(Float progress) {
+  public void setProgress(int progress) {
     set(DSL.PROGRESS, progress);
   }
 

--- a/src/main/java/com/creactiviti/piper/core/task/SimpleTaskExecution.java
+++ b/src/main/java/com/creactiviti/piper/core/task/SimpleTaskExecution.java
@@ -15,16 +15,16 @@
  */
 package com.creactiviti.piper.core.task;
 
-import java.time.Duration;
-import java.util.Collections;
-import java.util.Date;
-import java.util.Map;
-
 import com.creactiviti.piper.core.DSL;
 import com.creactiviti.piper.core.error.Error;
 import com.creactiviti.piper.core.error.ErrorObject;
 import com.creactiviti.piper.core.error.Prioritizable;
 import com.creactiviti.piper.core.uuid.UUIDGenerator;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
 
 
 public class SimpleTaskExecution extends SimplePipelineTask implements TaskExecution {
@@ -78,7 +78,16 @@ public class SimpleTaskExecution extends SimplePipelineTask implements TaskExecu
     if(status == null) return null;
     return TaskStatus.valueOf(status);
   }
-  
+
+  @Override
+  public Float getProgress() {
+    return get(DSL.PROGRESS, Float.class);
+  }
+
+  public void setProgess(Float progress) {
+    set(DSL.PROGRESS, progress);
+  }
+
   @Override
   public Object getOutput() {
     return get(DSL.OUTPUT);

--- a/src/main/java/com/creactiviti/piper/core/task/TaskExecution.java
+++ b/src/main/java/com/creactiviti/piper/core/task/TaskExecution.java
@@ -15,11 +15,12 @@
  */
 package com.creactiviti.piper.core.task;
 
-import java.util.Date;
-
 import com.creactiviti.piper.core.error.Errorable;
 import com.creactiviti.piper.core.error.Prioritizable;
+import com.creactiviti.piper.core.error.Progressable;
 import com.creactiviti.piper.core.error.Retryable;
+
+import java.util.Date;
 
 /**
  * <p>Extends the {@link PipelineTask} interface to add execution semantics to 
@@ -38,7 +39,7 @@ import com.creactiviti.piper.core.error.Retryable;
  * @author Arik Cohen
  * @since May 8, 2017
  */
-public interface TaskExecution extends PipelineTask, Errorable, Retryable, Prioritizable {
+public interface TaskExecution extends PipelineTask, Errorable, Retryable, Prioritizable, Progressable {
 
   /**
    * Get the unique id of the task instance.

--- a/src/main/java/com/creactiviti/piper/core/taskhandler/io/Download.java
+++ b/src/main/java/com/creactiviti/piper/core/taskhandler/io/Download.java
@@ -55,7 +55,7 @@ public class Download implements TaskHandler<Object> {
             if (connection.getResponseCode() / 100 == 2) {
                 File downloadedFile = File.createTempFile("download-", "", null);
                 int contentLength = connection.getContentLength();
-                Consumer<Float> progressConsumer =
+                Consumer<Integer> progressConsumer =
                         (p) -> eventPublisher.publishEvent(PiperEvent.of(Events.TASK_PROGRESSED,"taskId", ((TaskExecution)aTask).getId(), "progress", p));
 
                 try (BufferedInputStream in = new BufferedInputStream(connection.getInputStream());
@@ -76,12 +76,12 @@ public class Download implements TaskHandler<Object> {
     private static final class ProgressingOutputStream extends FilterOutputStream {
         private final int totalSize;
         private final OutputStream out;
-        private final Consumer<Float> progressConsumer;
+        private final Consumer<Integer> progressConsumer;
         private long count;
         private long lastTime;
-        private long delta = 1000;
+        private long delta = 500;
 
-        ProgressingOutputStream(OutputStream out, int totalSize, Consumer<Float> progressConsumer) {
+        ProgressingOutputStream(OutputStream out, int totalSize, Consumer<Integer> progressConsumer) {
             super(out);
 
             this.totalSize = totalSize;
@@ -108,11 +108,11 @@ public class Download implements TaskHandler<Object> {
                 long time = System.currentTimeMillis();
 
                 if( count == totalSize ) {
-                    progressConsumer.accept(1f);
+                    progressConsumer.accept(100);
                 }
 
                 if( time > lastTime + delta ) {
-                    Float p = count / (float)totalSize;
+                    int p = (int)(count * 100 / totalSize);
                     progressConsumer.accept(p);
                     lastTime = time;
                 }

--- a/src/main/java/com/creactiviti/piper/core/taskhandler/io/Download.java
+++ b/src/main/java/com/creactiviti/piper/core/taskhandler/io/Download.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.creactiviti.piper.core.taskhandler.io;
+
+import com.creactiviti.piper.core.annotations.ConditionalOnWorker;
+import com.creactiviti.piper.core.event.EventPublisher;
+import com.creactiviti.piper.core.event.Events;
+import com.creactiviti.piper.core.event.PiperEvent;
+import com.creactiviti.piper.core.task.Task;
+import com.creactiviti.piper.core.task.TaskExecution;
+import com.creactiviti.piper.core.task.TaskHandler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.function.Consumer;
+
+import static org.apache.commons.io.IOUtils.copy;
+
+/**
+ * Simple worker which performs the download of a file (given its URL).
+ *
+ * @since Sep 06, 2018
+ */
+@Component
+@ConditionalOnWorker
+public class Download implements TaskHandler<Object> {
+    @Autowired
+    @Qualifier("Worker")
+    EventPublisher eventPublisher;
+
+    @Override
+    public Object handle(Task aTask) {
+        try {
+            URL url = new URL(aTask.getRequiredString("url"));
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.connect();
+
+            if (connection.getResponseCode() / 100 == 2) {
+                File downloadedFile = File.createTempFile("download-", "", null);
+                int contentLength = connection.getContentLength();
+                Consumer<Float> progressConsumer =
+                        (p) -> eventPublisher.publishEvent(PiperEvent.of(Events.TASK_PROGRESSED,"taskId", ((TaskExecution)aTask).getId(), "progress", p));
+
+                try (BufferedInputStream in = new BufferedInputStream(connection.getInputStream());
+                     OutputStream os = new ProgressingOutputStream(new FileOutputStream(downloadedFile), contentLength, progressConsumer)) {
+
+                    copy(in, os);
+                }
+                return downloadedFile.toString();
+            }
+
+            throw new IllegalStateException("Server returned: " + connection.getResponseCode());
+
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static final class ProgressingOutputStream extends FilterOutputStream {
+        private final int totalSize;
+        private final OutputStream out;
+        private final Consumer<Float> progressConsumer;
+        private long count;
+        private long lastTime;
+        private long delta = 1000;
+
+        ProgressingOutputStream(OutputStream out, int totalSize, Consumer<Float> progressConsumer) {
+            super(out);
+
+            this.totalSize = totalSize;
+            this.out = out;
+            this.progressConsumer = progressConsumer;
+        }
+
+        public void write(byte[] b, int off, int len) throws IOException {
+            this.out.write(b, off, len);
+            this.count += (long) len;
+
+            report();
+        }
+
+        public void write(int b) throws IOException {
+            this.out.write(b);
+            ++this.count;
+
+            report();
+        }
+
+        void report() {
+            if(totalSize != -1 && totalSize != -0) {
+                long time = System.currentTimeMillis();
+
+                if( count == totalSize ) {
+                    progressConsumer.accept(1f);
+                }
+
+                if( time > lastTime + delta ) {
+                    Float p = count / (float)totalSize;
+                    progressConsumer.accept(p);
+                    lastTime = time;
+                }
+            }
+        }
+
+    }
+
+}

--- a/src/main/resources/pipelines/demo/download.yaml
+++ b/src/main/resources/pipelines/demo/download.yaml
@@ -1,0 +1,15 @@
+label: Download Demo
+
+outputs:
+  - name: Location of the file
+    value: ${download}
+    
+tasks:
+  - name: download
+    label: Download a file
+    type: download
+    url: http://ovh.net/files/10Mio.dat
+      
+  - label: Print location of the downloaded file
+    type: print
+    text: Downloaded file ${download}

--- a/src/main/resources/schema-h2.sql
+++ b/src/main/resources/schema-h2.sql
@@ -18,6 +18,7 @@ create table task_execution (
   id varchar(256) not null primary key,
   parent_id varchar(256),
   status varchar(256) not null,
+  progress decimal(5,2),
   job_id varchar(256) not null,
   create_time timestamp not null,
   start_time timestamp,

--- a/src/main/resources/schema-h2.sql
+++ b/src/main/resources/schema-h2.sql
@@ -18,7 +18,7 @@ create table task_execution (
   id varchar(256) not null primary key,
   parent_id varchar(256),
   status varchar(256) not null,
-  progress decimal(5,2),
+  progress int not null,
   job_id varchar(256) not null,
   create_time timestamp not null,
   start_time timestamp,

--- a/src/main/resources/schema-postgres.sql
+++ b/src/main/resources/schema-postgres.sql
@@ -25,6 +25,7 @@ create table task_execution (
   id varchar(256) not null primary key,
   parent_id varchar(256) null,
   status varchar(256) not null,
+  progress decimal(5,2),
   job_id varchar(256) not null,
   create_time timestamp not null,
   start_time timestamp,

--- a/src/main/resources/schema-postgres.sql
+++ b/src/main/resources/schema-postgres.sql
@@ -25,7 +25,7 @@ create table task_execution (
   id varchar(256) not null primary key,
   parent_id varchar(256) null,
   status varchar(256) not null,
-  progress decimal(5,2),
+  progress int not null,
   job_id varchar(256) not null,
   create_time timestamp not null,
   start_time timestamp,

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -18,6 +18,7 @@ create table task_execution (
   id varchar(256) not null primary key,
   parent_id varchar(256),
   status varchar(256) not null,
+  progress decimal(5,2),
   job_id varchar(256) not null,
   create_time timestamp not null,
   start_time timestamp,

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -18,7 +18,7 @@ create table task_execution (
   id varchar(256) not null primary key,
   parent_id varchar(256),
   status varchar(256) not null,
-  progress decimal(5,2),
+  progress int not null,
   job_id varchar(256) not null,
   create_time timestamp not null,
   start_time timestamp,


### PR DESCRIPTION
I would like to have the tasks of a job able to report their progress. Indeed, some tasks are actually long running process, and from the point of view of the user, it is valuable to have this feedback. I think it could be a good enhancement for `piper`.

This PR is a first proposal, fully functional though. I tried to keep it as simple as possible.

I have some questions:
- In this PR, I've introduced an additional database column. How do you plan to handle schema migrations in `piper`? Should I provide a migration script for this? I think so.
- I would like to improve the way a `worker` send back information to the `Coordinator`. As you will see, for the demonstration purpose I [used the injected eventPublisher instance](https://github.com/creactiviti/piper/compare/master...ccamel:add-task-progress?expand=1#diff-83f9fb35e47e5a2633b6ad4c06546495R59) and I forged the event by hand, but that way to do is inconvenient and fragile. It would be far better to have a dedicated mechanism to emit such notification from the [TaskHandler](https://github.com/creactiviti/piper/blob/master/src/main/java/com/creactiviti/piper/core/task/TaskHandler.java) without revealing the underlying machinery.

What do you think ?