### PR TITLE
Add mongodb support

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,13 +421,15 @@ piper.pipeline-repository.git.search-paths=demo/,video/
 piper.pipeline-repository.filesystem.enabled=true
 # location of pipelines on the file system.
 piper.pipeline-repository.filesystem.location-pattern=$HOME/piper/**/*.yaml
+# persistence
+piper.persistence.provider= # Persistence provider to use. Supports jdbc (for h2 and postgresql database) and mongo.
 # data source
 spring.datasource.initialize=true # Create the database using 'schema-{platform}.sql'.
 spring.datasource.name= # Name of the datasource.
-spring.datasource.password= # Login password of the database.
 spring.datasource.platform=h2 # Platform to use in the DDL or DML scripts. Supports h2 and postgres.
-spring.datasource.url= # JDBC url of the database.
-spring.datasource.username= # Login user of the database.
+spring.datasource.url= # Url of the database. Supports jdbc:// and mongdb://
+spring.datasource.username= # Login user of the database (for jdbc)
+spring.datasource.password= # Login password of the database (for jdbc)
 ```
 
 # Docker

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.mongodb</groupId>
+			<artifactId>mongodb-driver</artifactId>
+			<version>3.8.2</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
@@ -116,6 +122,13 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>de.flapdoodle.embed</groupId>
+			<artifactId>de.flapdoodle.embed.mongo</artifactId>
+			<version>2.1.1</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/main/java/com/creactiviti/piper/PiperApplication.java
+++ b/src/main/java/com/creactiviti/piper/PiperApplication.java
@@ -16,15 +16,24 @@
 package com.creactiviti.piper;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.system.ApplicationPidFileWriter;
 
-@SpringBootApplication
+@SpringBootApplication(
+    exclude = {
+        DataSourceAutoConfiguration.class,
+        DataSourceTransactionManagerAutoConfiguration.class,
+        HibernateJpaAutoConfiguration.class}
+)
 public class PiperApplication {
 
-	public static void main(String[] args) {
-		SpringApplication springApplication = new SpringApplication(PiperApplication.class);
-		springApplication.addListeners(new ApplicationPidFileWriter());
-		springApplication.run(args);
-	}
+  public static void main(String[] args) {
+    SpringApplication springApplication = new SpringApplication(PiperApplication.class);
+    springApplication.addListeners(new ApplicationPidFileWriter());
+    springApplication.run(args);
+  }
 }

--- a/src/main/java/com/creactiviti/piper/config/JdbcPersistenceConfiguration.java
+++ b/src/main/java/com/creactiviti/piper/config/JdbcPersistenceConfiguration.java
@@ -16,8 +16,12 @@
 package com.creactiviti.piper.config;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
@@ -30,6 +34,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Configuration
 @ConditionalOnProperty(name="piper.persistence.provider",havingValue="jdbc")
+@Import(value = {
+    DataSourceAutoConfiguration.class,
+    DataSourceTransactionManagerAutoConfiguration.class,
+    HibernateJpaAutoConfiguration.class})
 public class JdbcPersistenceConfiguration {
 
   @Bean

--- a/src/main/java/com/creactiviti/piper/config/MongoPersistenceConfiguration.java
+++ b/src/main/java/com/creactiviti/piper/config/MongoPersistenceConfiguration.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.creactiviti.piper.config;
+
+import com.creactiviti.piper.core.Accessor;
+import com.creactiviti.piper.core.DSL;
+import com.creactiviti.piper.core.context.Context;
+import com.creactiviti.piper.core.context.MapContext;
+import com.creactiviti.piper.core.context.MongoContextRepository;
+import com.creactiviti.piper.core.job.Job;
+import com.creactiviti.piper.core.job.MongoJobRepository;
+import com.creactiviti.piper.core.job.SimpleJob;
+import com.creactiviti.piper.core.task.MongoCounterRepository;
+import com.creactiviti.piper.core.task.MongoTaskExecutionRepository;
+import com.creactiviti.piper.core.task.SimpleTaskExecution;
+import com.creactiviti.piper.core.task.TaskExecution;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.mongodb.*;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoDatabase;
+import org.bson.BsonReader;
+import org.bson.BsonType;
+import org.bson.BsonWriter;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.configuration.CodecProvider;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.PojoCodecProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.net.URI;
+import java.util.*;
+
+import static com.mongodb.MongoClient.getDefaultCodecRegistry;
+import static java.util.Objects.nonNull;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Stream.of;
+import static org.bson.codecs.configuration.CodecRegistries.*;
+import static org.bson.codecs.pojo.Conventions.CLASS_AND_PROPERTY_CONVENTION;
+import static org.springframework.util.StringUtils.hasText;
+
+@Configuration
+@ConditionalOnProperty(name = "piper.persistence.provider", havingValue = "mongo")
+public class MongoPersistenceConfiguration {
+  @Bean
+  MongoTaskExecutionRepository mongoJobTaskRepository(MongoDatabase mongoDatabase, CodecRegistry codecRegistry) {
+    MongoTaskExecutionRepository mongoJobTaskRepository = new MongoTaskExecutionRepository(mongoDatabase);
+    return mongoJobTaskRepository;
+  }
+
+  @Bean
+  MongoJobRepository mongoJobRepository(MongoDatabase mongoDatabase, CodecRegistry codecRegistry) {
+    MongoJobRepository mongoJobRepository = new MongoJobRepository(mongoDatabase);
+    return mongoJobRepository;
+  }
+
+  @Bean
+  MongoContextRepository mongoContextRepository(MongoDatabase mongoDatabase, CodecRegistry codecRegistry, ObjectMapper objectMapper) {
+    MongoContextRepository mongoContextRepository = new MongoContextRepository(mongoDatabase);
+    return mongoContextRepository;
+  }
+
+  @Bean
+  MongoCounterRepository mongoCounterRepository(MongoDatabase mongoDatabase, CodecRegistry codecRegistry, ObjectMapper objectMapper) {
+    return new MongoCounterRepository(mongoDatabase);
+  }
+
+  @Bean
+  ConnectionString mongoConnectionString(@Value("${spring.datasource.url:mongodb://localhost:27017/piper}") URI datasourceURI) {
+    return new ConnectionString(datasourceURI.toString());
+  }
+
+  @Bean
+  MongoClient mongoClient(ConnectionString mongoConnectionString) {
+    return MongoClients.create(mongoConnectionString);
+  }
+
+  @Bean
+  MongoDatabase mongoDatabase(MongoClient mongoClient,
+                              ConnectionString mongoConnectionString,
+                              CodecRegistry codecRegistry) {
+    return mongoClient
+        .getDatabase(mongoConnectionString.getDatabase())
+        .withCodecRegistry(codecRegistry);
+  }
+
+  @Bean
+  CodecRegistry codecRegistry() {
+    PojoCodecProvider pojoCodecProvider = PojoCodecProvider
+        .builder()
+        .conventions(ImmutableList.of(CLASS_AND_PROPERTY_CONVENTION))
+        .register(Context.class)
+        .register(Job.class)
+        .register(TaskExecution.class)
+        .register(Error.class)
+        .register(Accessor.class)
+        .build();
+
+    return fromRegistries(
+        fromProviders(
+            new PiperCodecProvider(),
+            pojoCodecProvider,
+            new EnumPropertyCodecProvider()),
+        getDefaultCodecRegistry(),
+        fromCodecs(new StringArrayCodec())
+    );
+  }
+
+  public static class StringArrayCodec implements Codec<String[]> {
+    @Override
+    public void encode(final BsonWriter writer, final String[] values, final EncoderContext encoderContext) {
+      writer.writeStartArray();
+      for (String v : values) {
+        writer.writeString(v);
+      }
+      writer.writeEndArray();
+    }
+
+    @Override
+    public String[] decode(final BsonReader reader, final DecoderContext decoderContext) {
+      List<String> values = new ArrayList<>();
+      reader.readStartArray();
+      while (reader.getCurrentBsonType() != BsonType.STRING) {
+        values.add(reader.readString());
+      }
+      reader.readEndArray();
+
+      return values.toArray(new String[0]);
+    }
+
+    @Override
+    public Class<String[]> getEncoderClass() {
+      return String[].class;
+    }
+  }
+
+  final static class EnumPropertyCodecProvider implements CodecProvider {
+    EnumPropertyCodecProvider() {
+
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public <T> Codec<T> get(Class<T> clazz, CodecRegistry registry) {
+      if (Enum.class.isAssignableFrom(clazz)) {
+        return (Codec<T>) new EnumCodec(clazz);
+      }
+      return null;
+    }
+
+    private static class EnumCodec<T extends Enum<T>> implements Codec<T> {
+      private final Class<T> clazz;
+
+      EnumCodec(final Class<T> clazz) {
+        this.clazz = clazz;
+      }
+
+      @Override
+      public void encode(final BsonWriter writer, final T value, final EncoderContext encoderContext) {
+        writer.writeString(value.name());
+      }
+
+      @Override
+      public Class<T> getEncoderClass() {
+        return clazz;
+      }
+
+      @Override
+      public T decode(final BsonReader reader, final DecoderContext decoderContext) {
+        return Enum.valueOf(clazz, reader.readString());
+      }
+    }
+  }
+
+  public static class PiperCodecProvider implements CodecProvider {
+    @SuppressWarnings({"unchecked"})
+    @Override
+    public <T> Codec<T> get(final Class<T> clazz, final CodecRegistry registry) {
+      if (Job.class.isAssignableFrom(clazz)
+          || TaskExecution.class.isAssignableFrom(clazz)
+          || Context.class.isAssignableFrom(clazz)) {
+
+        return (Codec<T>) new AccessorCodec(clazz, registry);
+      }
+
+      // CodecProvider returns null if it's not a provider for the requested Class
+      return null;
+    }
+
+    private class AccessorCodec<T extends Accessor> implements Codec<T> {
+      final Class<T> clazz;
+      final CodecRegistry registry;
+
+      private AccessorCodec(Class<T> clazz, CodecRegistry registry) {
+        this.clazz = clazz;
+        this.registry = registry;
+      }
+
+      @SuppressWarnings({"unchecked"})
+      @Override
+      public T decode(BsonReader reader, DecoderContext decoderContext) {
+        Map m = registry
+            .get(Map.class)
+            .decode(reader, decoderContext);
+
+        ofNullable(m.remove("_id")).ifPresent(it -> m.put(DSL.ID, it));
+
+        if (TaskExecution.class.isAssignableFrom(clazz)) {
+          return clazz.cast(SimpleTaskExecution.createFromMap(m));
+        }
+
+        if (Job.class.isAssignableFrom(clazz)) {
+          return clazz.cast(new SimpleJob(m));
+        }
+
+        if (Context.class.isAssignableFrom(clazz)) {
+          return clazz.cast(new MapContext(m));
+        }
+
+        throw new IllegalArgumentException("Type not expected: " + clazz);
+      }
+
+      @Override
+      public void encode(BsonWriter writer, T value, EncoderContext encoderContext) {
+        Map map = value.asMap()
+            .entrySet()
+            .stream()
+            .collect(
+                LinkedHashMap::new,
+                (m, e) -> m.put(
+                    // use the well-known field name for mongo primary key
+                    e.getKey().equals(DSL.ID) ? "_id" : e.getKey(),
+                    // use mongodb BSON Date where relevant
+                    of(DSL.CREATE_TIME, DSL.START_TIME, DSL.END_TIME)
+                        .filter(it -> it.equals(e.getKey()))
+                        .filter(it -> nonNull(e.getValue()))
+                        .map(it -> (Object) value.getDate(it))
+                        .findFirst()
+                        .orElse(e.getValue())),
+                Map::putAll
+            );
+
+        registry
+            .get(Map.class)
+            .encode(writer, map, encoderContext);
+      }
+
+      @Override
+      public Class<T> getEncoderClass() {
+        return clazz;
+      }
+    }
+  }
+
+}

--- a/src/main/java/com/creactiviti/piper/core/context/JdbcContextRepository.java
+++ b/src/main/java/com/creactiviti/piper/core/context/JdbcContextRepository.java
@@ -34,7 +34,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author Arik Cohe
  * @since Apt 7, 2017
  */
-@Component
 public class JdbcContextRepository implements ContextRepository<Context> {
 
   private JdbcTemplate jdbc;

--- a/src/main/java/com/creactiviti/piper/core/context/MongoContextRepository.java
+++ b/src/main/java/com/creactiviti/piper/core/context/MongoContextRepository.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.creactiviti.piper.core.context;
+
+import com.creactiviti.piper.core.uuid.UUIDGenerator;
+import com.google.common.collect.ImmutableList;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentWriter;
+import org.bson.Document;
+import org.bson.codecs.EncoderContext;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import static com.mongodb.client.model.Aggregates.*;
+import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Sorts.descending;
+
+public class MongoContextRepository implements ContextRepository<Context> {
+
+  private final MongoCollection<Document> collection;
+
+  public MongoContextRepository(MongoDatabase aDatabase) {
+    this.collection = aDatabase
+        .getCollection("context");
+  }
+
+  @Override
+  public Context push(String aStackId, Context aContext) {
+    collection
+        .insertOne(new Document()
+            .append("_id", UUIDGenerator.generate())
+            .append("stackId", aStackId)
+            .append("context", contextToDocument(aContext))
+            .append("createTime", new Date())
+        );
+
+    return aContext;
+  }
+
+  @Override
+  public Context peek(String aStackId) {
+    Context context = collection
+        .withDocumentClass(Context.class)
+        .aggregate(ImmutableList.of(
+            match(eq("stackId", aStackId)),
+            sort(descending("createTime")),
+            limit(1),
+            replaceRoot("$context")
+        ))
+        .first();
+
+    if (context != null) {
+      return context;
+    }
+
+    return null;
+  }
+
+  @Override
+  public List<Context> getStack(String aStackId) {
+    return collection
+        .withDocumentClass(Context.class)
+        .aggregate(ImmutableList.of(
+            match(eq("stackId", aStackId)),
+            sort(descending("createTime")),
+            replaceRoot("$context")
+        ))
+        .into(new ArrayList<>());
+  }
+
+  private BsonDocument contextToDocument(Context aContext) {
+    BsonDocument doc = new BsonDocument();
+
+    collection
+        .getCodecRegistry()
+        .get(Context.class)
+        .encode(new BsonDocumentWriter(doc), aContext, EncoderContext.builder().isEncodingCollectibleDocument(true).build());
+
+    return doc;
+  }
+}

--- a/src/main/java/com/creactiviti/piper/core/context/MongoContextRepository.java
+++ b/src/main/java/com/creactiviti/piper/core/context/MongoContextRepository.java
@@ -15,6 +15,7 @@
  */
 package com.creactiviti.piper.core.context;
 
+import com.creactiviti.piper.core.DSL;
 import com.creactiviti.piper.core.uuid.UUIDGenerator;
 import com.google.common.collect.ImmutableList;
 import com.mongodb.client.MongoCollection;
@@ -24,13 +25,16 @@ import org.bson.BsonDocumentWriter;
 import org.bson.Document;
 import org.bson.codecs.EncoderContext;
 
+import javax.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
 import static com.mongodb.client.model.Aggregates.*;
 import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Indexes.ascending;
 import static com.mongodb.client.model.Sorts.descending;
+import static java.util.stream.Stream.of;
 
 public class MongoContextRepository implements ContextRepository<Context> {
 
@@ -94,5 +98,11 @@ public class MongoContextRepository implements ContextRepository<Context> {
         .encode(new BsonDocumentWriter(doc), aContext, EncoderContext.builder().isEncodingCollectibleDocument(true).build());
 
     return doc;
+  }
+
+  @PostConstruct
+  void ensureIndexes() {
+    of(DSL.CREATE_TIME, "stackId")
+        .forEach(it -> collection.createIndex(ascending(it)));
   }
 }

--- a/src/main/java/com/creactiviti/piper/core/job/MongoJobRepository.java
+++ b/src/main/java/com/creactiviti/piper/core/job/MongoJobRepository.java
@@ -26,17 +26,20 @@ import org.bson.BsonDocumentWriter;
 import org.bson.codecs.EncoderContext;
 import org.bson.conversions.Bson;
 
+import javax.annotation.PostConstruct;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static com.mongodb.client.model.Filters.*;
+import static com.mongodb.client.model.Indexes.ascending;
 import static com.mongodb.client.model.Updates.set;
 import static java.time.Instant.now;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Stream.of;
 
 public class MongoJobRepository implements JobRepository {
   private final MongoCollection<Job> collection;
@@ -150,5 +153,12 @@ public class MongoJobRepository implements JobRepository {
 
     return doc;
   }
+
+  @PostConstruct
+  void ensureIndexes() {
+    of(DSL.CREATE_TIME, DSL.START_TIME, DSL.END_TIME, DSL.PARENT_TASK_EXECUTION_ID, DSL.STATUS)
+        .forEach(it -> collection.createIndex(ascending(it)));
+  }
+
 
 }

--- a/src/main/java/com/creactiviti/piper/core/job/MongoJobRepository.java
+++ b/src/main/java/com/creactiviti/piper/core/job/MongoJobRepository.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.creactiviti.piper.core.job;
+
+import com.creactiviti.piper.core.DSL;
+import com.creactiviti.piper.core.Page;
+import com.creactiviti.piper.core.ResultPage;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Updates;
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentWriter;
+import org.bson.codecs.EncoderContext;
+import org.bson.conversions.Bson;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static com.mongodb.client.model.Filters.*;
+import static com.mongodb.client.model.Updates.set;
+import static java.time.Instant.now;
+import static java.time.temporal.ChronoUnit.DAYS;
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toList;
+
+public class MongoJobRepository implements JobRepository {
+  private final MongoCollection<Job> collection;
+
+  public static final int DEFAULT_PAGE_SIZE = 20;
+
+  public MongoJobRepository(MongoDatabase aDatabase) {
+    this.collection = aDatabase
+        .getCollection("job")
+        .withDocumentClass(Job.class);
+  }
+
+  @Override
+  public Job findOne(String aId) {
+    return collection
+        .find(eq("_id", aId))
+        .first();
+  }
+
+  @Override
+  public Job findJobByTaskId(String aTaskId) {
+    return collection
+        .find(elemMatch(DSL.EXECUTION, eq("_id", aTaskId)))
+        .first();
+  }
+
+  @Override
+  public Page<Job> findAll(int aPageNumber) {
+    int offset = (aPageNumber - 1) * DEFAULT_PAGE_SIZE;
+    int limit = DEFAULT_PAGE_SIZE;
+
+    List<Job> items = newArrayList(
+        collection
+            .find()
+            .skip(offset)
+            .limit(limit));
+
+    long totalItems = collection
+        .countDocuments();
+
+    ResultPage<Job> resultPage = new ResultPage<>(Job.class);
+    resultPage.setItems(items);
+    resultPage.setNumber(items.size() > 0 ? aPageNumber : 0);
+    resultPage.setTotalItems((int) totalItems);
+    resultPage.setTotalPages(items.size() > 0 ? (int) totalItems / DEFAULT_PAGE_SIZE + 1 : 0);
+    return resultPage;
+  }
+
+  @Override
+  public Job merge(Job aJob) {
+    Bson combinedUpdate = jobToBsonDocument(aJob)
+        .entrySet()
+        .stream()
+        .filter(it -> !DSL.EXECUTION.equals(it.getKey()))
+        .map(e -> set(e.getKey(), e.getValue()))
+        .collect(collectingAndThen(toList(), Updates::combine));
+
+    collection
+        .updateOne(
+            eq("_id", aJob.getId()),
+            combinedUpdate);
+
+    return aJob;
+  }
+
+  @Override
+  public void create(Job aJob) {
+    collection
+        .insertOne(aJob);
+  }
+
+  @Override
+  public int countRunningJobs() {
+    return
+        (int) collection
+            .countDocuments(eq(DSL.STATUS, JobStatus.CREATED));
+  }
+
+  @Override
+  public int countCompletedJobsToday() {
+    Date today = Date.from(now().truncatedTo(DAYS));
+
+    return (int) collection
+        .countDocuments(
+            and(
+                eq(DSL.STATUS, JobStatus.COMPLETED),
+                gte(DSL.END_TIME, today)));
+  }
+
+  @Override
+  public int countCompletedJobsYesterday() {
+    Instant today = now().truncatedTo(DAYS);
+    Instant yesterday = today.minus(1, DAYS);
+
+    return (int) collection
+        .countDocuments(
+            and(
+                eq(DSL.STATUS, JobStatus.COMPLETED),
+                gte(DSL.END_TIME, Date.from(yesterday)),
+                lt(DSL.END_TIME, Date.from(today))));
+  }
+
+
+  private BsonDocument jobToBsonDocument(Job aJob) {
+    BsonDocument doc = new BsonDocument();
+
+    collection
+        .getCodecRegistry()
+        .get(Job.class)
+        .encode(new BsonDocumentWriter(doc), aJob, EncoderContext.builder().isEncodingCollectibleDocument(true).build());
+
+    return doc;
+  }
+
+}

--- a/src/main/java/com/creactiviti/piper/core/task/MongoCounterRepository.java
+++ b/src/main/java/com/creactiviti/piper/core/task/MongoCounterRepository.java
@@ -22,12 +22,15 @@ import com.mongodb.client.model.FindOneAndUpdateOptions;
 import com.mongodb.client.model.Updates;
 import org.bson.Document;
 
+import javax.annotation.PostConstruct;
 import java.util.Date;
 
 import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Indexes.ascending;
 import static com.mongodb.client.model.Projections.include;
 import static com.mongodb.client.model.ReturnDocument.AFTER;
 import static com.mongodb.client.model.Updates.*;
+import static java.util.stream.Stream.of;
 
 public class MongoCounterRepository implements CounterRepository {
   private final MongoCollection<Document> collection;
@@ -70,11 +73,15 @@ public class MongoCounterRepository implements CounterRepository {
     return doc.getLong(DSL.VALUE);
   }
 
-
   @Override
   public void delete(String aCounterName) {
     collection
         .deleteOne(eq("_id", aCounterName));
   }
 
+  @PostConstruct
+  void ensureIndexes() {
+    of(DSL.CREATE_TIME)
+        .forEach(it -> collection.createIndex(ascending(it)));
+  }
 }

--- a/src/main/java/com/creactiviti/piper/core/task/MongoCounterRepository.java
+++ b/src/main/java/com/creactiviti/piper/core/task/MongoCounterRepository.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.creactiviti.piper.core.task;
+
+import com.creactiviti.piper.core.DSL;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.FindOneAndUpdateOptions;
+import com.mongodb.client.model.Updates;
+import org.bson.Document;
+
+import java.util.Date;
+
+import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Projections.include;
+import static com.mongodb.client.model.ReturnDocument.AFTER;
+import static com.mongodb.client.model.Updates.*;
+
+public class MongoCounterRepository implements CounterRepository {
+  private final MongoCollection<Document> collection;
+
+  public MongoCounterRepository(MongoDatabase aDatabase) {
+    this.collection = aDatabase
+        .getCollection("counter");
+  }
+
+  @Override
+  public void set(String aCounterName, long aValue) {
+    collection
+        .findOneAndUpdate(
+            eq("_id", aCounterName),
+            combine(
+                Updates.set(DSL.VALUE, aValue),
+                setOnInsert("_id", aCounterName),
+                setOnInsert(DSL.CREATE_TIME, new Date())
+            ),
+            new FindOneAndUpdateOptions()
+                .upsert(true)
+        );
+  }
+
+  @Override
+  public long decrement(String aCounterName) {
+    Document doc = collection
+        .findOneAndUpdate(
+            eq("_id", aCounterName),
+            inc(DSL.VALUE, -1),
+            new FindOneAndUpdateOptions()
+                .returnDocument(AFTER)
+                .projection(include(DSL.VALUE))
+        );
+
+    if (doc == null) {
+      throw new IllegalArgumentException("Counter not found: " + aCounterName);
+    }
+
+    return doc.getLong(DSL.VALUE);
+  }
+
+
+  @Override
+  public void delete(String aCounterName) {
+    collection
+        .deleteOne(eq("_id", aCounterName));
+  }
+
+}

--- a/src/main/java/com/creactiviti/piper/core/task/MongoTaskExecutionRepository.java
+++ b/src/main/java/com/creactiviti/piper/core/task/MongoTaskExecutionRepository.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.creactiviti.piper.core.task;
+
+import com.creactiviti.piper.core.DSL;
+import com.google.common.collect.ImmutableList;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.mongodb.client.model.Aggregates.*;
+import static com.mongodb.client.model.Filters.and;
+import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Updates.push;
+import static com.mongodb.client.model.Updates.set;
+import static java.text.MessageFormat.format;
+
+public class MongoTaskExecutionRepository implements TaskExecutionRepository {
+  private final MongoCollection<TaskExecution> collection;
+
+  public MongoTaskExecutionRepository(MongoDatabase database) {
+    this.collection = database
+        .getCollection("job")
+        .withDocumentClass(TaskExecution.class);
+  }
+
+  @Override
+  public TaskExecution findOne(String aId) {
+    return collection
+        .aggregate(ImmutableList.of(
+            unwind('$' + DSL.EXECUTION),
+            match(eq(format("{0}._id", DSL.EXECUTION), aId)),
+            replaceRoot('$' + DSL.EXECUTION)
+        ))
+        .first();
+  }
+
+  @Override
+  public List<TaskExecution> findByParentId(String aParentId) {
+    return collection
+        .aggregate(ImmutableList.of(
+            unwind('$' + DSL.EXECUTION),
+            match(eq(format("{0}.parentId", DSL.EXECUTION), aParentId)),
+            unwind('$' + DSL.EXECUTION)
+        ))
+        .into(new ArrayList<>());
+  }
+
+
+  @Override
+  public void create(TaskExecution aTaskExecution) {
+    collection
+        .updateOne(
+            eq("_id", aTaskExecution.getJobId()),
+            push(DSL.EXECUTION, aTaskExecution)
+        );
+  }
+
+  @Override
+  public TaskExecution merge(TaskExecution aTaskExecution) {
+    collection
+        .updateOne(
+            and(eq("_id", aTaskExecution.getJobId()), eq("execution._id", aTaskExecution.getId())),
+            set(format("{0}.$", DSL.EXECUTION), aTaskExecution)
+        );
+
+    return aTaskExecution;
+  }
+
+  @Override
+  public List<TaskExecution> getExecution(String aJobId) {
+    return collection
+        .aggregate(ImmutableList.of(
+            match(eq("_id", aJobId)),
+            unwind('$' + DSL.EXECUTION),
+            replaceRoot('$' + DSL.EXECUTION)
+        ))
+        .into(new ArrayList<>());
+  }
+}

--- a/src/main/java/com/creactiviti/piper/core/task/MongoTaskExecutionRepository.java
+++ b/src/main/java/com/creactiviti/piper/core/task/MongoTaskExecutionRepository.java
@@ -20,15 +20,18 @@ import com.google.common.collect.ImmutableList;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 
+import javax.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.List;
 
 import static com.mongodb.client.model.Aggregates.*;
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Indexes.ascending;
 import static com.mongodb.client.model.Updates.push;
 import static com.mongodb.client.model.Updates.set;
 import static java.text.MessageFormat.format;
+import static java.util.stream.Stream.of;
 
 public class MongoTaskExecutionRepository implements TaskExecutionRepository {
   private final MongoCollection<TaskExecution> collection;
@@ -91,5 +94,11 @@ public class MongoTaskExecutionRepository implements TaskExecutionRepository {
             replaceRoot('$' + DSL.EXECUTION)
         ))
         .into(new ArrayList<>());
+  }
+
+  @PostConstruct
+  void ensureIndexes() {
+    of(DSL.CREATE_TIME, DSL.START_TIME, DSL.END_TIME, DSL.JOB_ID, DSL.STATUS)
+        .forEach(it -> collection.createIndex(ascending(format("{0}.{1}", DSL.EXECUTION, it))));
   }
 }

--- a/src/test/java/com/creactiviti/piper/core/job/MongoJobRepositoryTests.java
+++ b/src/test/java/com/creactiviti/piper/core/job/MongoJobRepositoryTests.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.creactiviti.piper.core.job;
+
+import com.creactiviti.piper.config.MongoPersistenceConfiguration;
+import com.creactiviti.piper.core.DSL;
+import com.creactiviti.piper.core.Page;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.flapdoodle.embed.mongo.MongodExecutable;
+import de.flapdoodle.embed.mongo.MongodProcess;
+import de.flapdoodle.embed.mongo.MongodStarter;
+import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
+import de.flapdoodle.embed.mongo.config.Net;
+import de.flapdoodle.embed.mongo.distribution.Version;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.util.SocketUtils;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+
+import static com.creactiviti.piper.core.job.MongoJobRepository.DEFAULT_PAGE_SIZE;
+import static com.creactiviti.piper.core.job.MongoJobRepositoryTests.MongoJobRepositoryTestsContextConfiguration;
+import static com.creactiviti.piper.core.job.MongoJobRepositoryTests.MongodbInitailizer;
+import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
+import static de.flapdoodle.embed.process.runtime.Network.localhostIsIPv6;
+import static java.text.MessageFormat.format;
+import static java.time.temporal.ChronoUnit.DAYS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD;
+import static org.springframework.test.context.support.TestPropertySourceUtils.addInlinedPropertiesToEnvironment;
+
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = {
+    MongoPersistenceConfiguration.class,
+    MongoJobRepositoryTestsContextConfiguration.class},
+    properties = {"piper.persistence.provider=mongo"}
+)
+@ContextConfiguration(initializers = MongodbInitailizer.class)
+@DirtiesContext(classMode = BEFORE_EACH_TEST_METHOD)
+public class MongoJobRepositoryTests {
+  @TestConfiguration
+  static class MongoJobRepositoryTestsContextConfiguration {
+    @Bean
+    public ObjectMapper objectMapper() {
+      return new ObjectMapper()
+          .configure(WRITE_DATES_AS_TIMESTAMPS, false)
+          .setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZZ"));
+    }
+  }
+
+  public static class MongodbInitailizer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+    @Override
+    public void initialize(ConfigurableApplicationContext applicationContext) {
+      int randomPort = SocketUtils.findAvailableTcpPort();
+      addInlinedPropertiesToEnvironment(applicationContext, format("spring.datasource.url=mongodb://{0}:{1,number,0}/piper", "localhost", randomPort));
+
+      try {
+        MongodExecutable mongodExe = starter
+            .prepare(new MongodConfigBuilder()
+                .version(Version.Main.PRODUCTION)
+                .net(new Net(randomPort, localhostIsIPv6()))
+                .build());
+
+        MongodProcess mongod = mongodExe.start();
+
+        applicationContext.addApplicationListener(e -> {
+          if (e instanceof ContextClosedEvent) {
+            mongod.stop();
+            mongodExe.stop();
+          }
+        });
+      } catch (IOException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+  }
+
+  private static final MongodStarter starter = MongodStarter.getDefaultInstance();
+  private static final DateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
+
+  @Autowired
+  MongoJobRepository jobRepository;
+
+  @Test
+  public void test1() {
+    // arrange
+    Date now = new Date();
+
+    SimpleJob job = new SimpleJob();
+    job.setPipelineId("demo:1234");
+    job.setId("1");
+    job.setCreateTime(now);
+    job.setStatus(JobStatus.STARTED);
+    job.set(DSL.START_TIME, dateFormatter.format(now));
+
+    // act
+    jobRepository.create(job);
+    Job one = jobRepository.findOne("1");
+
+    // assert
+    assertNotNull(one);
+    assertEquals(now, one.getCreateTime());
+    assertEquals(JobStatus.STARTED, one.getStatus());
+    assertEquals(now, ((Map) one).get(DSL.START_TIME));
+  }
+
+
+  @Test
+  public void test2() {
+    // arrange
+    Date now = new Date();
+
+    int total = DEFAULT_PAGE_SIZE + 3;
+    for (int i = 0; i < total; i++) {
+      SimpleJob job = new SimpleJob();
+      job.setPipelineId("demo:1234");
+      job.setId("" + i);
+      job.setCreateTime(now);
+      job.setStatus(JobStatus.CREATED);
+      jobRepository.create(job);
+    }
+    // act
+    Page<Job> all = jobRepository.findAll(1);
+
+    // assert
+    assertEquals(DEFAULT_PAGE_SIZE, all.getSize());
+    assertEquals(1, all.getNumber());
+    assertEquals(20, all.getSize());
+    assertEquals(total, all.getTotalItems());
+  }
+
+  @Test
+  public void test3() {
+    SimpleJob job = new SimpleJob();
+    job.setId("2");
+    job.setPipelineId("demo:1234");
+    job.setCreateTime(new Date());
+    job.setStatus(JobStatus.CREATED);
+    jobRepository.create(job);
+
+    Job one = jobRepository.findOne("2");
+
+    SimpleJob mjob = new SimpleJob(one);
+    mjob.setStatus(JobStatus.FAILED);
+
+    // test immutability
+    Assert.assertNotEquals(mjob.getStatus().toString(), one.getStatus().toString());
+
+    jobRepository.merge(mjob);
+    one = jobRepository.findOne("2");
+    assertEquals("FAILED", one.getStatus().toString());
+  }
+
+  @Test
+  public void test4() {
+    // arrange
+    SimpleJob completedJobYesterday = new SimpleJob();
+    completedJobYesterday.setId("1");
+    completedJobYesterday.setPipelineId("demo:1234");
+    completedJobYesterday.setCreateTime(Date.from(Instant.now().minus(2, DAYS)));
+    completedJobYesterday.setStatus(JobStatus.COMPLETED);
+    jobRepository.create(completedJobYesterday);
+    completedJobYesterday.setEndTime(Date.from(Instant.now().minus(1, DAYS)));
+    jobRepository.merge(completedJobYesterday);
+
+    for (int i = 0; i < 5; i++) {
+      SimpleJob completedJobToday = new SimpleJob();
+      completedJobToday.setId("2." + i);
+      completedJobToday.setPipelineId("demo:1234");
+      completedJobToday.setCreateTime(Date.from(Instant.now().minus(1, DAYS)));
+      completedJobToday.setStatus(JobStatus.COMPLETED);
+      jobRepository.create(completedJobToday);
+      completedJobToday.setEndTime(new Date());
+      jobRepository.merge(completedJobToday);
+    }
+
+    SimpleJob runningJobToday = new SimpleJob();
+    runningJobToday.setId("3");
+    runningJobToday.setPipelineId("demo:1234");
+    runningJobToday.setCreateTime(new Date());
+    runningJobToday.setStatus(JobStatus.STARTED);
+    jobRepository.create(runningJobToday);
+
+    // act
+    int todayJobs = jobRepository.countCompletedJobsToday();
+
+    // assert
+    Assert.assertEquals(5, todayJobs);
+  }
+
+  @Test
+  public void test5() {
+    // arrange
+    for (int i = 0; i < 5; i++) {
+      SimpleJob completedJobYesterday = new SimpleJob();
+      completedJobYesterday.setId("1." + i);
+      completedJobYesterday.setPipelineId("demo:1234");
+      completedJobYesterday.setCreateTime(Date.from(Instant.now().minus(2, DAYS)));
+      completedJobYesterday.setStatus(JobStatus.COMPLETED);
+      jobRepository.create(completedJobYesterday);
+      completedJobYesterday.setEndTime(Date.from(Instant.now().minus(1, DAYS)));
+      jobRepository.merge(completedJobYesterday);
+    }
+
+    SimpleJob runningJobYesterday = new SimpleJob();
+    runningJobYesterday.setId("2");
+    runningJobYesterday.setPipelineId("demo:1234");
+    runningJobYesterday.setCreateTime(Date.from(Instant.now().minus(1, DAYS)));
+    runningJobYesterday.setStatus(JobStatus.STARTED);
+    jobRepository.create(runningJobYesterday);
+
+    SimpleJob completedJobToday = new SimpleJob();
+    completedJobToday.setId("3");
+    completedJobToday.setPipelineId("demo:1234");
+    completedJobToday.setCreateTime(Date.from(Instant.now().minus(1, DAYS)));
+    completedJobToday.setStatus(JobStatus.COMPLETED);
+    jobRepository.create(completedJobToday);
+    completedJobToday.setEndTime(new Date());
+    jobRepository.merge(completedJobToday);
+
+    // act
+    int yesterdayJobs = jobRepository.countCompletedJobsYesterday();
+
+    // assert
+    Assert.assertEquals(5, yesterdayJobs);
+  }
+
+}

--- a/src/test/java/com/creactiviti/piper/core/task/MongoCounterRepositoryTests.java
+++ b/src/test/java/com/creactiviti/piper/core/task/MongoCounterRepositoryTests.java
@@ -1,0 +1,131 @@
+package com.creactiviti.piper.core.task;
+
+import com.creactiviti.piper.config.MongoPersistenceConfiguration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.flapdoodle.embed.mongo.MongodExecutable;
+import de.flapdoodle.embed.mongo.MongodProcess;
+import de.flapdoodle.embed.mongo.MongodStarter;
+import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
+import de.flapdoodle.embed.mongo.config.Net;
+import de.flapdoodle.embed.mongo.distribution.Version;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.util.SocketUtils;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import static com.creactiviti.piper.core.task.MongoCounterRepositoryTests.MongoCounterRepositoryTestsContextConfiguration;
+import static com.creactiviti.piper.core.task.MongoCounterRepositoryTests.MongodbInitailizer;
+import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
+import static de.flapdoodle.embed.process.runtime.Network.localhostIsIPv6;
+import static java.text.MessageFormat.format;
+import static org.junit.Assert.assertEquals;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD;
+import static org.springframework.test.context.support.TestPropertySourceUtils.addInlinedPropertiesToEnvironment;
+
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = {
+    MongoPersistenceConfiguration.class,
+    MongoCounterRepositoryTestsContextConfiguration.class},
+    properties = {"piper.persistence.provider=mongo"}
+)
+@ContextConfiguration(initializers = MongodbInitailizer.class)
+@DirtiesContext(classMode = BEFORE_EACH_TEST_METHOD)
+public class MongoCounterRepositoryTests {
+  @TestConfiguration
+  static class MongoCounterRepositoryTestsContextConfiguration {
+    @Bean
+    public ObjectMapper objectMapper() {
+      return new ObjectMapper()
+          .configure(WRITE_DATES_AS_TIMESTAMPS, false)
+          .setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZZ"));
+    }
+  }
+
+  public static class MongodbInitailizer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+    @Override
+    public void initialize(ConfigurableApplicationContext applicationContext) {
+      int randomPort = SocketUtils.findAvailableTcpPort();
+      addInlinedPropertiesToEnvironment(applicationContext, format("spring.datasource.url=mongodb://{0}:{1,number,0}/piper", "localhost", randomPort));
+
+      try {
+        MongodExecutable mongodExe = starter
+            .prepare(new MongodConfigBuilder()
+                .version(Version.Main.PRODUCTION)
+                .net(new Net(randomPort, localhostIsIPv6()))
+                .build());
+
+        MongodProcess mongod = mongodExe.start();
+
+        applicationContext.addApplicationListener(e -> {
+          if (e instanceof ContextClosedEvent) {
+            mongod.stop();
+            mongodExe.stop();
+          }
+        });
+      } catch (IOException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+  }
+
+  private static final MongodStarter starter = MongodStarter.getDefaultInstance();
+  private static final DateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
+
+  @Autowired
+  MongoCounterRepository counterRepository;
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void test1() {
+    counterRepository.set("my-counter-1", 1);
+    counterRepository.set("my-counter-2", 2);
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Counter not found: my-counter-3");
+
+    counterRepository.decrement("my-counter-3");
+  }
+
+  @Test
+  public void test2() {
+    counterRepository.set("my-counter-1", 1);
+    counterRepository.set("my-counter-2", 2);
+    counterRepository.set("my-counter-3", 3);
+
+    long v = counterRepository.decrement("my-counter-2");
+
+    assertEquals(1, v);
+  }
+
+  @Test
+  public void test3() {
+    counterRepository.set("my-counter-1", 1);
+    counterRepository.set("my-counter-2", 2);
+
+    counterRepository.delete("my-counter-1");
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Counter not found: my-counter-1");
+
+    counterRepository.decrement("my-counter-1");
+  }
+
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,2 @@
+#spring
+spring.main.banner-mode=off


### PR DESCRIPTION
@creactiviti 
Here is the implementation of the `mongodb` support I did. Sorry, 😓 I did not see that you had closed the issue #24 in favour of #25. But I think the support of such a NoSQL database is still interesting, even with JSON support for `PostgreSQL`. For a professional use case, I intend to use piper with `mongodb`. 

I let you judge. :smile: 